### PR TITLE
To convert BRAN Calendar from 'GREGORIAN' to 'gregorian'

### DIFF
--- a/BRAN/BRAN Readme.txt
+++ b/BRAN/BRAN Readme.txt
@@ -1,0 +1,4 @@
+To download BRAN files use the BRAN_Download code.
+
+After downloading files, in order to make them PARCELS compatible, the calendar type needs to be redefined.
+To do this, run the Fix_BRAN_calendar_type code which converts the type from "GREGORIAN" to "gregorian".

--- a/BRAN/Fix_BRAN_calendar_type.R
+++ b/BRAN/Fix_BRAN_calendar_type.R
@@ -1,0 +1,42 @@
+# This code redefines the calendar type of the BRAN model files from "GREGORIAN" to "gregorian" to make it readable by PARCELS
+# Hayden Schilling
+# 25/9/20
+
+library(ncdf4)
+
+file_list <- list.files("../../srv/scratch/z3374139/BRAN_AUS/", recursive = T, full.names = T, pattern ="Ocean_")
+
+for (i in file_list){
+
+mydata <- nc_open(i, write = TRUE)
+
+#head(mydata)
+#str(mydata)
+
+ncatt_put(mydata, "Time", 'calendar', attval = 'gregorian', prec = 'text')
+ncatt_put(mydata, "Time", 'calendar_type', attval = 'gregorian', prec = 'text')
+
+ncatt_get(mydata, "Time")
+
+nc_sync(mydata)
+nc_close(mydata)
+}
+
+# # Code for single file
+# 
+# mydata <- nc_open("C:/Users/hayde/Crab-Dispersal/BRAN/AUS/ocean_v_1994_01.nc", write = TRUE)
+# 
+# head(mydata)
+# str(mydata)
+# 
+# mydata$dim$Time
+# 
+# ncatt_put(mydata, "Time", 'calendar', attval = 'gregorian', prec = 'text')
+# ncatt_put(mydata, "Time", 'calendar_type', attval = 'gregorian', prec = 'text')
+# mydata$dim$Time
+# 
+# ncatt_get(mydata, "Time")
+# 
+# nc_sync(mydata)
+# nc_close(mydata)
+

--- a/BRAN/Fix_BRAN_calendar_type.pbs
+++ b/BRAN/Fix_BRAN_calendar_type.pbs
@@ -1,0 +1,16 @@
+#!/bin/bash
+ 
+#PBS -l select=1:ncpus=1:mem=20gb
+#PBS -l walltime=12:00:00
+#PBS -j oe
+#PBS -M h.schilling@unsw.edu.au
+#PBS -m ae
+
+ 
+cd $HOME
+
+module purge
+
+module add R/3.6.1
+
+Rscript Fix_BRAN_calendar_type.R


### PR DESCRIPTION
An R script to open each BRAN file and convert the calendar type to 'gregorian' in order to make it compatible with the PARCELS calendar reader. Close #4 